### PR TITLE
Add py3 spport and conform to PEP8

### DIFF
--- a/pyspark_csv.py
+++ b/pyspark_csv.py
@@ -25,18 +25,17 @@ SOFTWARE.
 import csv
 import sys
 import dateutil.parser
-from pyspark import sql
-from pyspark.sql import *
-from pyspark.sql.types import *
+from pyspark.sql.types import (StringType, DoubleType, TimestampType, NullType,
+                               IntegerType, StructType, StructField)
 
 py_version = sys.version_info[0]
 
-"""
-Convert CSV plain text RDD into SparkSQL DataFrame (former SchemaRDD) using PySpark
-If columns not given, assume first row is the header
-If separator not given, assume comma separated
-"""
-def csvToDataFrame(sqlCtx,rdd,columns=None,sep=",",parseDate=True):
+
+def csvToDataFrame(sqlCtx, rdd, columns=None, sep=",", parseDate=True):
+    """Converts CSV plain text RDD into SparkSQL DataFrame (former SchemaRDD)
+    using PySpark. If columns not given, assumes first row is the header.
+    If separator not given, assumes comma separated
+    """
     if py_version < 3:
         def toRow(line):
             return toRowSep(line.encode('utf-8'), sep)
@@ -46,31 +45,42 @@ def csvToDataFrame(sqlCtx,rdd,columns=None,sep=",",parseDate=True):
 
     rdd_array = rdd.map(toRow)
     rdd_sql = rdd_array
+
     if columns is None:
         columns = rdd_array.first()
         rdd_sql = rdd_array.zipWithIndex().filter(
             lambda r_i: r_i[1] > 0).keys()
-    column_types = evaluateType(rdd_sql,parseDate)
+    column_types = evaluateType(rdd_sql, parseDate)
+
     def toSqlRow(row):
-        return toSqlRowWithType(row,column_types)
-    schema = makeSchema(zip(columns,column_types)) 
+        return toSqlRowWithType(row, column_types)
+
+    schema = makeSchema(zip(columns, column_types))
+
     return sqlCtx.createDataFrame(rdd_sql.map(toSqlRow), schema=schema)
 
+
 def makeSchema(columns):
-    struct_field_map = { 'string':StringType(), 'date': TimestampType(), 'double': DoubleType(), 'int': IntegerType(), 'none':NullType()}
-    fields = [StructField(k, struct_field_map[v], True) for k,v in columns]
+    struct_field_map = {'string': StringType(),
+                        'date': TimestampType(),
+                        'double': DoubleType(),
+                        'int': IntegerType(),
+                        'none': NullType()}
+    fields = [StructField(k, struct_field_map[v], True) for k, v in columns]
+
     return StructType(fields)
 
-# Parse a row using csv.reader	
-def toRowSep(line,d):
-    for r in csv.reader([line], delimiter=d):
-        return r 
-        
 
-# Actual conversion to sql.Row
-def toSqlRowWithType(row,col_types):
-    d = row 
-    for col,data in enumerate(row):
+def toRowSep(line, d):
+    """Parses one row using csv reader"""
+    for r in csv.reader([line], delimiter=d):
+        return r
+
+
+def toSqlRowWithType(row, col_types):
+    """Convert to sql.Row"""
+    d = row
+    for col, data in enumerate(row):
         typed = col_types[col]
         if isNone(data):
             d[col] = None
@@ -78,65 +88,75 @@ def toSqlRowWithType(row,col_types):
             d[col] = data
         elif typed == 'int':
             d[col] = int(round(float(data)))
-        elif typed =='double': 
+        elif typed == 'double':
             d[col] = float(data)
         elif typed == 'date':
             d[col] = toDate(data)
     return d
-	
+
+
 # Type converter
 def isNone(d):
-    return (d is None or d == 'None' or d == '?' or d == '' or d == 'NULL' or d == 'null')
+    return (d is None or d == 'None' or
+            d == '?' or
+            d == '' or
+            d == 'NULL' or
+            d == 'null')
+
 
 def toDate(d):
     return dateutil.parser.parse(d)
 
-# Infer types for each row
+
 def getRowType(row):
-    d = row 
-    for col,data in enumerate(row):        
+    """Infers types for each row"""
+    d = row
+    for col, data in enumerate(row):
         try:
             if isNone(data):
                 d[col] = 'none'
             else:
-                num = float(data) 
+                num = float(data)
                 if num.is_integer():
-                    d[col] = 'int'            
+                    d[col] = 'int'
                 else:
                     d[col] = 'double'
         except:
             try:
-                dt = toDate(data)
+                toDate(data)
                 d[col] = 'date'
             except:
-                dt = data
                 d[col] = 'string'
     return d
-    
-# Infer types for each row
+
+
 def getRowTypeNoDate(row):
-    d = row 
-    for col,data in enumerate(row):        
+    """Infers types for each row"""
+    d = row
+    for col, data in enumerate(row):
         try:
             if isNone(data):
                 d[col] = 'none'
             else:
-                num = float(data) 
+                num = float(data)
                 if num.is_integer():
-                    d[col] = 'int'            
+                    d[col] = 'int'
                 else:
                     d[col] = 'double'
         except:
             d[col] = 'string'
     return d
- 
-# Reduce column types among rows to find common denominator 
-def reduceTypes(a,b):
-    type_order = {'string':0, 'date':1, 'double':2, 'int':3, 'none':4}
-    reduce_map = {'int': {0:'string', 1:'string',2:'double'}, 'double': {0:'string',1:'string'}, 'date': {0:'string'}}    
-    d = a      
+
+
+def reduceTypes(a, b):
+    """Reduces column types among rows to find common denominator"""
+    type_order = {'string': 0, 'date': 1, 'double': 2, 'int': 3, 'none': 4}
+    reduce_map = {'int': {0: 'string', 1: 'string', 2: 'double'},
+                  'double': {0: 'string', 1: 'string'},
+                  'date': {0: 'string'}}
+    d = a
     for col, a_type in enumerate(a):
-        #a_type = a[col]
+        # a_type = a[col]
         b_type = b[col]
         if a_type == 'none':
             d[col] = b_type
@@ -146,19 +166,16 @@ def reduceTypes(a,b):
             order_a = type_order[a_type]
             order_b = type_order[b_type]
             if order_a == order_b:
-                d[col] = a_type                
+                d[col] = a_type
             elif order_a > order_b:
                 d[col] = reduce_map[a_type][order_b]
             elif order_a < order_b:
-                d[col] = reduce_map[b_type][order_a]           
+                d[col] = reduce_map[b_type][order_a]
     return d
-        
-def evaluateType(rdd_sql,parseDate):
+
+
+def evaluateType(rdd_sql, parseDate):
     if parseDate:
         return rdd_sql.map(getRowType).reduce(reduceTypes)
     else:
         return rdd_sql.map(getRowTypeNoDate).reduce(reduceTypes)
-
-
-		
- 


### PR DESCRIPTION
Since version 1.4, pyspark supports Python3, which we use in our projects. I have added:
- python3 support (although not extensively tested: only on the data I have)
- conformance with PEP8 style guidelines

Please, try running this in Py3 on whatever data you have to see if it works properly. It works as expected on my data
